### PR TITLE
Census improvements

### DIFF
--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -57,16 +57,6 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
     super.merge(date_of_birth: Date.parse(first_date_of_birth_element.text).to_s)
   end
 
-  def scope
-    Decidim::Scope.find(scope_id)
-  end
-
-  def census_document_types
-    %i(dni nie passport).map do |type|
-      [I18n.t(type, scope: "decidim.census_authorization_handler.document_types"), type]
-    end
-  end
-
   def unique_id
     Digest::MD5.hexdigest(
       "#{document_number}-#{Rails.application.secrets.secret_key_base}"
@@ -74,12 +64,6 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   private
-
-  def document_type_valid
-    return nil if response.blank?
-
-    #errors.add(:document_number, I18n.t("census_authorization_handler.invalid_document")) unless response.xpath("//codiRetorn").text == "01"
-  end
 
   def registered_in_town
     return nil if response.blank?

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -94,6 +94,8 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
 
   def census_date_of_birth_coincidence
     errors.add(:date_of_birth, I18n.t("census_authorization_handler.invalid_date_of_birth")) unless first_person_element&.text&.blank? || first_date_of_birth_element && date_of_birth == Date.parse(first_date_of_birth_element.text)
+    return if (errors.keys - [:date_of_birth]).any? # Don't add more errors if user is not in census
+
   end
 
   def response

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -133,7 +133,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
       OpenStruct.new(body: stubbed_fail_body)
     else
       Faraday.new(:url => Rails.application.secrets.census_url).get do |request|
-        request.url("findEmpadronat", dni: document_number)
+        request.url("findEmpadronat", dni: document_number.upcase)
       end
     end
   end

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -67,6 +67,8 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
 
   def registered_in_town
     return nil if response.blank?
+    return if errors.key?(:document_number) # Don't need to check if document format is invalid
+
     errors.add(:document_number, i18_error_msg(:not_in_census)) unless first_person_element.present? && first_person_element.text != ""
   end
 

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -144,12 +144,23 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   def log_census_request(response)
     compact_document = document_number.gsub(/\s+/, "").upcase
 
-    Rails.logger.debug "[Census Service][#{user.id}][request] unique_id: #{unique_id} document_filtered: #{compact_document.gsub(/(?!^).(?!$)(?!.{3,4}$)/,"*")} birthdate: #{date_of_birth}"
-    Rails.logger.debug "[Census Service][#{user.id}][response] status: #{response.status} body: #{response.body}"
+    Rails.logger.debug "[Census Service][#{user.id}][request] unique_id: #{unique_id} document_filtered: #{compact_document.gsub(/(?!^).(?!$)(?!.{3,4}$)/,"*")} birthdate: #{date_of_birth.year}-**-#{date_of_birth.day}"
+    Rails.logger.debug "[Census Service][#{user.id}][response] status: #{response.status} body: #{obfuscated_response_body(response)}"
   end
 
   def i18_error_msg(error_key)
     I18n.t("census_authorization_handler.#{error_key}")
+  end
+
+  def obfuscated_response_body(response)
+    response.body.gsub(/<edat>.*<\/edat>/, "<edat>**</edat>")
+                 .gsub(/<haborddir>.*<\/haborddir>/, "<haborddir>*****</haborddir>")
+                 .gsub(/<habtoddir>.*<\/habtoddir>/, "<habtoddir>*****</habtoddir>")
+                 .gsub(/<sexe>.*<\/sexe>/, "<sexe>*</sexe>")
+                 .gsub(/<habap2hab>.*<\/habap2hab>/, "<habap2hab>*****</habap2hab>")
+                 .gsub(/<habfecnac>.*<\/habfecnac>/, "<habfecnac>****-**-**</habfecnac>")
+                 .gsub(/<habnomcom>.*<\/habnomcom>/, "<habnomcom>*****</habnomcom>")
+                 .gsub(/<habnomhab>.*<\/habnomhab>/, "<habnomhab>*****</habnomhab>")
   end
 
   class ActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -7,7 +7,7 @@ ca:
   activemodel:
     attributes:
       census_authorization_handler:
-        document_number: Número de document
+        document_number: "DNI o NIE (ex: 12345678A, X1234567A)"
         document_type: Tipus de document
         postal_code: Codi postal
         date_of_birth: Data de naixement

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -2,6 +2,8 @@ ca:
   census_authorization_handler:
     invalid_date_of_birth: Data de naixement incorrecta
     invalid_document: Número de document incorrecte
+    not_in_census: No empadronat
+    not_old_enough: Menor de 16 anys
   activemodel:
     attributes:
       census_authorization_handler:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,7 +7,7 @@ es:
   activemodel:
     attributes:
       census_authorization_handler:
-        document_number: Número de documento
+        document_number: "DNI o NIE (ej: 12345678A, X1234567A)"
         document_type: Tipo de documento
         postal_code: Código postal
         date_of_birth: Fecha de nacimiento

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2,6 +2,8 @@ es:
   census_authorization_handler:
     invalid_date_of_birth: Fecha de nacimiento incorrecta
     invalid_document: Número de documento incorrecto
+    not_in_census: No empadronado
+    not_old_enough: Menor de 16 años
   activemodel:
     attributes:
       census_authorization_handler:


### PR DESCRIPTION
### What does this PR do?

- Adds missing translations
- Fixes errors displayed in the UI. Some are moved to the `:document_number` key (otherwise styles were broken). Also avoids birthdate error when user is not in census (it's confusing).
- Avoids making a request to the census (and showing the fail error) if the document format is not valid.
- Removes useless methods
- Fixes the regular expressions to validate DNI and NIE formats
- Adds descriptive field labels
- Converts document letters to upcase before making census request
- Anonymizes personal information form the log. Now it has this format:

```
[Census Service][2781][request] unique_id: 61d2c6fe40ac65179f368bffe10ca739 document_filtered: 3***12**R birthdate: 1994-**-15
[Census Service][2781][response] status: 200 body: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><ssagavaVigents><ssagavaVigent><edat>**</edat><habap1hab>GARCIA</habap1hab><habap2hab>*****</habap2hab><habfecnac>****-**-**</habfecnac><habnomcom>*****</habnomcom><habnomhab>*****</habnomhab><haborddir>*****</haborddir><habtoddir>*****</habtoddir><sexe>*</sexe></ssagavaVigent></ssagavaVigents>
```

### How to test this

#### Regular expressions

To test the regular espressions you can get the full values from the console:

```ruby
CensusAuthorizationHandler::DOCUMENT_REGEXP_TEST
/\A((?-mix:\d{8}[a-zA-Z])|(?-mix:[a-zA-Z]\d{7}[a-zA-Z]))(\+|-|!)?\z/
CensusAuthorizationHandler::DOCUMENT_REGEXP_PROD
/\A((?-mix:\d{8}[a-zA-Z])|(?-mix:[a-zA-Z]\d{7}[a-zA-Z]))\z/
```

and then test combinations in rubular.

#### Form interactions

In https://gava.populate.tools/ login with `user@decidim.dev` / `decidim123456` and test different interactions. For a successful verification user the last of the three test DNIs we were given with this birthdate: `1995-01-15`.