### PR TITLE
Add Rack::Attack configuration to application config file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,3 +38,11 @@ module DecidimBarcelona
     config.eager_load_paths += required_files
   end
 end
+
+Decidim.configure do |config|
+  # Max requests in a time period to prevent DoS attacks. Only applied on production.
+  config.throttling_max_requests = 1000
+
+  # Time window in which the throttling is applied.
+  # config.throttling_period = 1.minute
+end


### PR DESCRIPTION
Related to PopulateTools/issues#1473

This PR changes configuration of `Rack::Attack` and raises the `throttling_max_requests` to 1000