### PR TITLE
Add smtp settings in staging

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -76,10 +76,14 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
 
   ## Mailing
-  config.action_mailer.delivery_method = :letter_opener_web
   config.action_mailer.smtp_settings = {
-    address: Rails.application.secrets.smtp_address,
-    port:    Rails.application.secrets.smtp_port,
-    domain:  Rails.application.secrets.smtp_domain
+    address:        Rails.application.secrets.smtp_address,
+    port:           Rails.application.secrets.smtp_port,
+    authentication: Rails.application.secrets.smtp_authentication,
+    user_name:      Rails.application.secrets.smtp_username,
+    password:       Rails.application.secrets.smtp_password,
+    domain:         Rails.application.secrets.smtp_domain,
+    enable_starttls_auto: Rails.application.secrets.smtp_starttls_auto,
+    openssl_verify_mode: "none"
   }
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -30,7 +30,7 @@ default: &default
   smtp_password: <%= ENV["SMTP_PASSWORD"] %>
   smtp_address: <%= ENV["SMTP_ADDRESS"] %>
   smtp_domain: <%= ENV["SMTP_DOMAIN"] %>
-  smtp_port: <%= ENV["SMTP_PORT"] %>
+  smtp_port: <%= ENV["SMTP_PORT"] || "587" %>
   smtp_starttls_auto: true
   smtp_authentication: "plain"
   mailer_sender: <%= ENV["MAILER_SENDER"] %>


### PR DESCRIPTION
Related to PopulateTools/issues#1538

This PR sets staging to use smtp instead of letter_opener_web